### PR TITLE
feat: add DIO and Harvest pitch algorithms via pyworld

### DIFF
--- a/algorithms/__init__.py
+++ b/algorithms/__init__.py
@@ -29,6 +29,8 @@ _ALGORITHM_METADATA = {
         "RMVPEPitchAlgorithm",
         ["torch"],
     ),
+    "DIO": ("dio", "DIOPitchAlgorithm", ["pyworld"]),
+    "Harvest": ("harvest", "HarvestPitchAlgorithm", ["pyworld"]),
 }
 
 # The _REGISTRY now acts as a cache for lazily loaded algorithms.

--- a/algorithms/dio.py
+++ b/algorithms/dio.py
@@ -12,15 +12,20 @@ class DIOPitchAlgorithm(ThresholdPitchAlgorithm):
     ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
         audio64 = audio.astype(np.float64)
         frame_period = self.hop_size / self.sample_rate * 1000.0  # ms
+        # DIO expects a special range.
+        # Map threshold from [0,1] to [0.02,0.2]
+        norm_threshold = 0.02 + threshold * (0.2 - 0.02)
+
         f0, t = pw.dio(
             audio64,
             self.sample_rate,
             f0_floor=self.fmin,
             f0_ceil=self.fmax,
             frame_period=frame_period,
+            allowed_range=norm_threshold,
         )
         f0 = pw.stonemask(audio64, f0, t, self.sample_rate)
         return t, f0, (f0 >= self.fmin).astype(np.float32)
 
     def _get_default_threshold(self) -> float:
-        return 0.5
+        return 0.444

--- a/algorithms/dio.py
+++ b/algorithms/dio.py
@@ -1,0 +1,26 @@
+from typing import Tuple
+
+import numpy as np
+import pyworld as pw
+
+from .base import ThresholdPitchAlgorithm
+
+
+class DIOPitchAlgorithm(ThresholdPitchAlgorithm):
+    def _extract_pitch_with_threshold(
+        self, audio: np.ndarray, threshold: float
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+        audio64 = audio.astype(np.float64)
+        frame_period = self.hop_size / self.sample_rate * 1000.0  # ms
+        f0, t = pw.dio(
+            audio64,
+            self.sample_rate,
+            f0_floor=self.fmin,
+            f0_ceil=self.fmax,
+            frame_period=frame_period,
+        )
+        f0 = pw.stonemask(audio64, f0, t, self.sample_rate)
+        return t, f0, (f0 >= self.fmin).astype(np.float32)
+
+    def _get_default_threshold(self) -> float:
+        return 0.5

--- a/algorithms/harvest.py
+++ b/algorithms/harvest.py
@@ -1,0 +1,25 @@
+from typing import Tuple
+
+import numpy as np
+import pyworld as pw
+
+from .base import ThresholdPitchAlgorithm
+
+
+class HarvestPitchAlgorithm(ThresholdPitchAlgorithm):
+    def _extract_pitch_with_threshold(
+        self, audio: np.ndarray, threshold: float
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+        audio64 = audio.astype(np.float64)
+        frame_period = self.hop_size / self.sample_rate * 1000.0  # ms
+        f0, t = pw.harvest(
+            audio64,
+            self.sample_rate,
+            f0_floor=self.fmin,
+            f0_ceil=self.fmax,
+            frame_period=frame_period,
+        )
+        return t, f0, (f0 >= self.fmin).astype(np.float32)
+
+    def _get_default_threshold(self) -> float:
+        return 0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -121,4 +121,4 @@ wheel==0.45.1
 wrapt==1.17.2
 yapecs==0.4.0
 tensorflow-hub==0.16.1
-pyworld
+pyworld==0.3.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -121,3 +121,4 @@ wheel==0.45.1
 wrapt==1.17.2
 yapecs==0.4.0
 tensorflow-hub==0.16.1
+pyworld


### PR DESCRIPTION
- Add DIOPitchAlgorithm (algorithms/dio.py) using pyworld.dio with Stonemask refinement for improved F0 accuracy
- Add HarvestPitchAlgorithm (algorithms/harvest.py) using pyworld.harvest
- Register both algorithms in algorithms/__init__.py
- Add pyworld to requirements.txt

DIO and Harvest, both are well-known algorithms in text-to-speech community.